### PR TITLE
Update BCI micro version to 15.4

### DIFF
--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.suse.com/bci/bci-micro:15.3
+FROM registry.suse.com/bci/bci-micro:15.4
 RUN echo 'prometheus:x:1000:1000::/home/prometheus:/bin/bash' >> /etc/passwd && \
     echo 'prometheus:x:1000:' >> /etc/group && \
     mkdir /home/prometheus && \


### PR DESCRIPTION
Update BCI micro version to 15.4, because 15.3 is reaching EOL.

Signed-off-by: Guilherme Macedo <guilherme.macedo@suse.com>