### PR TITLE
Deprecate usage of RC versions in prometheus-federator repo

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,24 +3,14 @@ Related Issue: <!-- link the issue or issues this PR resolves here -->
 
 ### Checklist
 
-In general, the rules for bumping versions are:
-- If the current version is an RC, increment it `0.0.0-rc1` -> `0.0.0-rc2`
-- If the current version is not an RC, bump the patch and set it to `-rc1` (`0.0.0` -> `0.0.1-rc1`)
-
 Please fill out this table to identify which fields need to be modified in your PR.
 
 **Under `Status`, either indicate `Does Not Apply` or `Added to this PR`**.
 
-| **Field to be modified**                                              | Why should this be modified?                                                                                                           | Status                                      |
+| **Version to be incremented**                                              | Why should this be modified?                                                                                                           | Status                                      |
 |-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
-| `version` in rancher-project-monitoring `Chart.yaml`                  | - You modified the contents of the `rancher-project-monitoring` chart to make changes                                                    |  |
+| `version` in rancher-project-monitoring `Chart.yaml`                  | You modified the contents of the `rancher-project-monitoring` chart to make changes                                                    |  |
 | `helmProjectOperator.image.tag` in prometheus-federator `values.yaml` | Either you modified the rancher-project-monitoring chart or you modified the `main.go` file                                          |  |
 | `appVersion` in prometheus-federator `Chart.yaml`                     | You modified the `helmProjectOperator.image.tag` in the above box                                                                      |  |
 | `version` in prometheus-federator `Chart.yaml`                        | Either you modified the `appVersion` in the above box or you modified the contents of the `prometheus-federator` chart to make changes |  |
-
-### For Maintainers Releasing The Chart On QA Validation
-
-Please checkmark **both** of the boxes below to indicate that you have followed the versioning guidelines for `prometheus-federator`:
-- [ ] The `-rc` tag has been removed from the `version` in `packages/prometheus-federator/charts/Chart.yaml`
-- [ ] The `-rc` tag has been removed from the `helmProjectOperator.image.tag` in `packages/prometheus-federator/charts/values.yaml`
 

--- a/README.md
+++ b/README.md
@@ -43,13 +43,7 @@ For more information, see the [Developing guide](docs/developing.md).
 
 While this repository does maintain a standalone Helm repository for vanilla Helm users to consume directly, users of Rancher will see forked versions of these chart releases available on Rancher's Apps & Marketplace; the forked chart releases are maintained in the [`rancher/charts`](https://github.com/rancher/charts) repository on being released from a `dev-vX.X` branch to a `release-vX.X` branch, where `X.X` corresponds to the Rancher `${Major}.${Minor}` version that the users is using (i.e. Rancher `2.7`). 
 
-**The chart in rancher/charts is generally the version that is intended for use in production since that is the chart that will be tested by Rancher's QA team.** Generally, these charts will match the un-RCed charts available in this repository, so non-Rancher users **should** be able to safely use non-RC versions in this repository for production use cases (at their own risk).
-
-In order to facilitate this release cadence, when filing PRs to this repository with changes to the charts, community members will always be expected to bump the version in [packages/prometheus-federator/package.yaml](packages/prometheus-federator/charts/Chart.yaml) and [packages/rancher-project-monitoring/package.yaml](packages/rancher-project-monitoring/charts/Chart.yaml) in a particular fashion.
-
-A checkmark list that can be followed to match these versioning expectations can be found in the [pull request template](.github/pull_request_template.md).
-
-Generally, these rules ensure that the version in this repository will remain an `-rc` version until it has been fully validated for a Rancher release.
+**The chart in rancher/charts is generally the version that is intended for use in production since that is the chart that will be tested by Rancher's QA team.** Generally, these charts will match stable versions of charts available in this repository, so non-Rancher users **should** be able to safely use those versions in this repository for production use cases (at their own risk).
 
 For more information on the process maintainers of this repository use to mirror these charts over to [`rancher/charts`](https://github.com/rancher/charts), see the [Rancher release guide](docs/rancher_release.md).
 

--- a/docs/rancher_release.md
+++ b/docs/rancher_release.md
@@ -1,11 +1,5 @@
 # Making Charts Available on [`rancher/charts`](https://github.com/rancher/charts)
 
-## Removing RC Versions Prior to A Rancher Release
-
-Once QA has validated the contents of the final `-rc` version in the [`rancher/charts`](https://github.com/rancher/charts) branch that contains changes for this release, file a PR to this repository to remove the `-rc` from the `version` in `packages/prometheus-federator/charts/Chart.yaml` and `helmProjectOperator.image.tag` in `packages/prometheus-federator/charts/values.yaml`.
-
-Then follow the steps below to mirror the change into [`rancher/charts`](https://github.com/rancher/charts).
-
 ## On Any PR Merge
 
 Any time a PR is merged into this repository, the chart should be mirrored to the corresponding package in all branches of [`rancher/charts`](https://github.com/rancher/charts) that represent active release lines (i.e. `dev-v2.6`, `dev-v2.7`). To do this, do the following steps:
@@ -13,11 +7,10 @@ Any time a PR is merged into this repository, the chart should be mirrored to th
 Prior to making changes to [`rancher/charts`](https://github.com/rancher/charts), you will need to cut a GitHub tag / release to trigger CI into creating [the Project Operator Image on DockerHub](https://hub.docker.com/r/rancher/prometheus-federator):
 1. Navigate to the page to [`Draft a new release`](https://github.com/rancher/prometheus-federator/releases/new)
 2. On the `Choose a tag` dropdown, carefully type in the version **prefixed with `v`** that corresponds to the version of Prometheus Federator that was just merged in the PR (i.e. the value found on the `version` field of [`packages/prometheus-federator/charts/Chart.yaml`](../packages/prometheus-federator/charts/Chart.yaml)).
-3. Copy the tag name into the Release Name field (i.e. `vX.X.X` or `vX.X.X-rcX`)
+3. Copy the tag name into the Release Name field (i.e. `vX.X.X`)
 4. Click on the button that says `Generate release notes`
-5. If this is an `-rc` release, checkmark the box that says `This is a pre-release`. 
-6. **Review all your changes**; once a tag is created, **it should never be deleted**.
-7. Click on `Publish Release`
+5. **Review all your changes**; once a tag is created, **it should never be deleted**.
+6. Click on `Publish Release`
 
 Once the release has been published, wait till the Drone build successfully finishes and ensure that [the Project Operator Repo on DockerHub](https://hub.docker.com/r/rancher/prometheus-federator) contains the newly built image.
 


### PR DESCRIPTION
Introducing RC versions at rancher/prometheus-federator creates a complicated release process for community members and maintainers.

Instead, Prometheus Federator will always bump the patch version on changes (like other upstream repositories) and specific stable patches will be pulled into Rancher.