### PR TITLE
Add chart Debug method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ kubeconfig*.yaml
 get_helm.sh
 Dockerfile.dapper*
 !Dockerfile.dapper
+/.debug

--- a/cmd/prometheus-federator/main.go
+++ b/cmd/prometheus-federator/main.go
@@ -9,6 +9,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 
+	"github.com/rancher/prometheus-federator/pkg/debug"
 	"github.com/rancher/prometheus-federator/pkg/helm-project-operator/controllers/common"
 	"github.com/rancher/prometheus-federator/pkg/helm-project-operator/operator"
 	"github.com/rancher/prometheus-federator/pkg/version"
@@ -84,5 +85,6 @@ func main() {
 		Version: version.FriendlyVersion(),
 	})
 	cmd = command.AddDebug(cmd, &debugConfig)
+	cmd.AddCommand(debug.ChartDebugSubCommand(base64TgzChart))
 	command.Main(cmd)
 }

--- a/pkg/debug/chart.go
+++ b/pkg/debug/chart.go
@@ -15,136 +15,156 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	chartOnly bool
+)
+
 func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
 	chartDebug := &cobra.Command{
 		Use:   "debug-chart",
 		Short: "This command helps debug the internal chart files",
-		Run: func(cmd *cobra.Command, _ []string) {
-			chartOnly, _ := cmd.Flags().GetBool("chart-only")
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if chartOnly {
 				logrus.Info("Only the embedded chart's `Chart.yaml` will be exported.")
 			} else {
 				logrus.Info("The entire embedded chart wil be exported.")
 			}
 
-			chartTarballData, err := base64.StdEncoding.DecodeString(base64ChartTarball)
+			tarReader, err := readEmbeddedHelmChart(base64ChartTarball)
 			if err != nil {
-				fmt.Println("error:", err)
-				return
+				return err
 			}
-
-			gzipReader, err := gzip.NewReader(bytes.NewReader(chartTarballData))
-			if err != nil {
-				fmt.Println("Error creating gzip reader:", err)
-				return
-			}
-			defer gzipReader.Close()
-
-			// Create a tar reader
-			tarReader := tar.NewReader(gzipReader)
 
 			// Extract files to the current working directory
 			cwd, err := os.Getwd()
 			if err != nil {
-				fmt.Println("Error getting current working directory:", err)
-				return
+				return fmt.Errorf("error getting current working directory: %v", err)
 			}
 			debugDir := filepath.Join(cwd, ".debug")
 			// Ensure the .debug directory exists
 			if err := os.MkdirAll(debugDir, 0755); err != nil {
-				fmt.Println("Error creating .debug directory:", err)
-				return
+				return fmt.Errorf("error creating .debug directory: %v", err)
 			}
 
-			// Extract files to the .debug directory
-			for {
-				header, err := tarReader.Next()
-				if err == io.EOF {
-					// End of archive
-					break
-				}
-				if err != nil {
-					fmt.Println("Error reading tarball:", err)
-					return
-				}
-
-				// Determine the path to extract the file to
-				filePath := filepath.Join(debugDir, header.Name)
-
-				if chartOnly {
-					switch header.Typeflag {
-					case tar.TypeReg:
-						if header.Name == "rancher-project-monitoring/Chart.yaml" {
-							logrus.Info("Found a `Chart.yaml` file to export.")
-							// Ensure the parent directory exists
-							parentDir := filepath.Dir(filePath)
-							if err := os.MkdirAll(parentDir, 0755); err != nil {
-								logrus.Error("Error creating parent directory:", err)
-								return
-							}
-
-							// Create regular file
-							outFile, err := os.Create(filePath)
-							if err != nil {
-								logrus.Error("Error creating file:", err)
-								return
-							}
-
-							// Copy file content
-							if _, err := io.Copy(outFile, tarReader); err != nil {
-								logrus.Error("Error writing file content:", err)
-								outFile.Close()
-								return
-							}
-							logrus.Info("The `Chart.yaml` file was exported")
-							outFile.Close()
-						} else {
-							logrus.Debugf("Skipping file: %s\n", header.Name)
-						}
-					default:
-						logrus.Debugf("Skipping file: %s\n", header.Name)
-					}
-
-					return
-				}
-
-				switch header.Typeflag {
-				case tar.TypeDir:
-					// Create directory
-					if err := os.MkdirAll(filePath, os.FileMode(header.Mode)); err != nil {
-						fmt.Println("Error creating directory:", err)
-						return
-					}
-				case tar.TypeReg:
-					// Ensure the parent directory exists
-					parentDir := filepath.Dir(filePath)
-					if err := os.MkdirAll(parentDir, 0755); err != nil {
-						fmt.Println("Error creating parent directory:", err)
-						return
-					}
-
-					// Create regular file
-					outFile, err := os.Create(filePath)
-					if err != nil {
-						fmt.Println("Error creating file:", err)
-						return
-					}
-
-					// Copy file content
-					if _, err := io.Copy(outFile, tarReader); err != nil {
-						fmt.Println("Error writing file content:", err)
-						outFile.Close()
-						return
-					}
-					outFile.Close()
-				default:
-					fmt.Printf("Skipping unsupported file type: %s\n", header.Name)
-				}
+			err = extractChartData(tarReader, debugDir, chartOnly)
+			if err != nil {
+				return err
 			}
 
-			fmt.Println("Chart files successfully extracted to", debugDir)
+			logrus.Infof("Chart files successfully extracted to: %s", debugDir)
+			return nil
 		},
 	}
-	chartDebug.PersistentFlags().BoolP("chart-only", "C", false, "When set, only the `Chart.yaml` will be exported.")
+	chartDebug.Flags().BoolVarP(&chartOnly, "chart-only", "C", false, "When set, only the `Chart.yaml` will be exported.")
 	return chartDebug
+}
+
+func readEmbeddedHelmChart(base64ChartTarball string) (*tar.Reader, error) {
+	chartTarballData, err := base64.StdEncoding.DecodeString(base64ChartTarball)
+	if err != nil {
+		return nil, fmt.Errorf("error reading embedded chart data from base64: %v", err)
+	}
+
+	gzipReader, err := gzip.NewReader(bytes.NewReader(chartTarballData))
+	if err != nil {
+		return nil, fmt.Errorf("error creating gzip reader: %v", err)
+	}
+	defer gzipReader.Close()
+
+	// Create a tar reader
+	tarReader := tar.NewReader(gzipReader)
+	return tarReader, nil
+}
+
+func extractChartData(tarReader *tar.Reader, debugDir string, chartOnly bool) error {
+	// Extract files to the .debug directory
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			// End of archive
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("error reading tarball: %v", err)
+		}
+
+		// Determine the path to extract the file to
+		filePath := filepath.Join(debugDir, header.Name)
+
+		if chartOnly {
+			err = extractChartYamlFile(tarReader, header, filePath)
+		} else {
+			err = extractAllChartData(tarReader, header, filePath)
+		}
+
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func extractChartYamlFile(tarReader *tar.Reader, header *tar.Header, filePath string) error {
+	switch header.Typeflag {
+	case tar.TypeReg:
+		if header.Name == "rancher-project-monitoring/Chart.yaml" {
+			logrus.Info("Found a `Chart.yaml` file to export.")
+			// Ensure the parent directory exists
+			parentDir := filepath.Dir(filePath)
+			if err := os.MkdirAll(parentDir, 0755); err != nil {
+				return fmt.Errorf("error creating parent directory: %v", err)
+			}
+
+			// Create regular file
+			outFile, err := os.Create(filePath)
+			if err != nil {
+				return fmt.Errorf("error creating file: %v", err)
+			}
+
+			// Copy file content
+			if _, err := io.Copy(outFile, tarReader); err != nil {
+				outFile.Close()
+				return fmt.Errorf("error writing file content: %v", err)
+			}
+			logrus.Info("The `Chart.yaml` file was exported")
+			outFile.Close()
+		} else {
+			logrus.Debugf("Skipping file: %s\n", header.Name)
+		}
+	default:
+		logrus.Debugf("Skipping file: %s\n", header.Name)
+	}
+	return nil
+}
+
+func extractAllChartData(tarReader *tar.Reader, header *tar.Header, filePath string) error {
+	switch header.Typeflag {
+	case tar.TypeDir:
+		// Create directory
+		if err := os.MkdirAll(filePath, os.FileMode(header.Mode)); err != nil {
+			return fmt.Errorf("error creating directory: %v", err)
+		}
+	case tar.TypeReg:
+		// Ensure the parent directory exists
+		parentDir := filepath.Dir(filePath)
+		if err := os.MkdirAll(parentDir, 0755); err != nil {
+			return fmt.Errorf("error creating parent directory: %v", err)
+		}
+
+		// Create regular file
+		outFile, err := os.Create(filePath)
+		if err != nil {
+			return fmt.Errorf("error creating file: %v", err)
+		}
+
+		// Copy file content
+		if _, err := io.Copy(outFile, tarReader); err != nil {
+			outFile.Close()
+			return fmt.Errorf("error writing file content: %v", err)
+		}
+		outFile.Close()
+	default:
+		logrus.Debugf("Skipping unsupported file type: %s\n", header.Name)
+	}
+	return nil
 }

--- a/pkg/debug/chart.go
+++ b/pkg/debug/chart.go
@@ -1,0 +1,106 @@
+package debug
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"fmt"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
+	return &cobra.Command{
+		Use:   "debug-chart",
+		Short: "This command helps debug the internal chart files",
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Println("TODO debug")
+			// TODO: use straing data from base64ChartTarball to:
+			// Un-base64 the data to get a raw tgz file,
+			// Prompt for user input - in the future, for now just use local CWD,
+			// Save the files of the charts tar extracted to the local CWD
+			chartTarballData, err := base64.StdEncoding.DecodeString(base64ChartTarball)
+			if err != nil {
+				fmt.Println("error:", err)
+				return
+			}
+
+			gzipReader, err := gzip.NewReader(bytes.NewReader(chartTarballData))
+			if err != nil {
+				fmt.Println("Error creating gzip reader:", err)
+				return
+			}
+			defer gzipReader.Close()
+
+			// Create a tar reader
+			tarReader := tar.NewReader(gzipReader)
+
+			// Extract files to the current working directory
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Println("Error getting current working directory:", err)
+				return
+			}
+			debugDir := filepath.Join(cwd, ".debug")
+			// Ensure the .debug directory exists
+			if err := os.MkdirAll(debugDir, 0755); err != nil {
+				fmt.Println("Error creating .debug directory:", err)
+				return
+			}
+
+			// Extract files to the .debug directory
+			for {
+				header, err := tarReader.Next()
+				if err == io.EOF {
+					// End of archive
+					break
+				}
+				if err != nil {
+					fmt.Println("Error reading tarball:", err)
+					return
+				}
+
+				// Determine the path to extract the file to
+				filePath := filepath.Join(debugDir, header.Name)
+
+				switch header.Typeflag {
+				case tar.TypeDir:
+					// Create directory
+					if err := os.MkdirAll(filePath, os.FileMode(header.Mode)); err != nil {
+						fmt.Println("Error creating directory:", err)
+						return
+					}
+				case tar.TypeReg:
+					// Ensure the parent directory exists
+					parentDir := filepath.Dir(filePath)
+					if err := os.MkdirAll(parentDir, 0755); err != nil {
+						fmt.Println("Error creating parent directory:", err)
+						return
+					}
+
+					// Create regular file
+					outFile, err := os.Create(filePath)
+					if err != nil {
+						fmt.Println("Error creating file:", err)
+						return
+					}
+
+					// Copy file content
+					if _, err := io.Copy(outFile, tarReader); err != nil {
+						fmt.Println("Error writing file content:", err)
+						outFile.Close()
+						return
+					}
+					outFile.Close()
+				default:
+					fmt.Printf("Skipping unsupported file type: %s\n", header.Name)
+				}
+			}
+
+			fmt.Println("Chart files successfully extracted to", debugDir)
+		},
+	}
+}

--- a/pkg/debug/chart.go
+++ b/pkg/debug/chart.go
@@ -10,19 +10,23 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/spf13/cobra"
 )
 
 func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
-	return &cobra.Command{
+	chartDebug := &cobra.Command{
 		Use:   "debug-chart",
 		Short: "This command helps debug the internal chart files",
-		Run: func(_ *cobra.Command, _ []string) {
-			fmt.Println("TODO debug")
-			// TODO: use straing data from base64ChartTarball to:
-			// Un-base64 the data to get a raw tgz file,
-			// Prompt for user input - in the future, for now just use local CWD,
-			// Save the files of the charts tar extracted to the local CWD
+		Run: func(cmd *cobra.Command, _ []string) {
+			chartOnly, _ := cmd.Flags().GetBool("chart-only")
+			if chartOnly {
+				logrus.Info("Only the embedded chart's `Chart.yaml` will be exported.")
+			} else {
+				logrus.Info("The entire embedded chart wil be exported.")
+			}
+
 			chartTarballData, err := base64.StdEncoding.DecodeString(base64ChartTarball)
 			if err != nil {
 				fmt.Println("error:", err)
@@ -67,6 +71,43 @@ func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
 				// Determine the path to extract the file to
 				filePath := filepath.Join(debugDir, header.Name)
 
+				if chartOnly {
+					switch header.Typeflag {
+					case tar.TypeReg:
+						if header.Name == "rancher-project-monitoring/Chart.yaml" {
+							logrus.Info("Found a `Chart.yaml` file to export.")
+							// Ensure the parent directory exists
+							parentDir := filepath.Dir(filePath)
+							if err := os.MkdirAll(parentDir, 0755); err != nil {
+								logrus.Error("Error creating parent directory:", err)
+								return
+							}
+
+							// Create regular file
+							outFile, err := os.Create(filePath)
+							if err != nil {
+								logrus.Error("Error creating file:", err)
+								return
+							}
+
+							// Copy file content
+							if _, err := io.Copy(outFile, tarReader); err != nil {
+								logrus.Error("Error writing file content:", err)
+								outFile.Close()
+								return
+							}
+							logrus.Info("The `Chart.yaml` file was exported")
+							outFile.Close()
+						} else {
+							logrus.Debugf("Skipping file: %s\n", header.Name)
+						}
+					default:
+						logrus.Debugf("Skipping file: %s\n", header.Name)
+					}
+
+					return
+				}
+
 				switch header.Typeflag {
 				case tar.TypeDir:
 					// Create directory
@@ -104,4 +145,6 @@ func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
 			fmt.Println("Chart files successfully extracted to", debugDir)
 		},
 	}
+	chartDebug.PersistentFlags().BoolP("chart-only", "C", false, "When set, only the `Chart.yaml` will be exported.")
+	return chartDebug
 }

--- a/pkg/debug/chart.go
+++ b/pkg/debug/chart.go
@@ -15,11 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	chartOnly bool
-)
-
 func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
+	var chartOnly bool
 	chartDebug := &cobra.Command{
 		Use:   "debug-chart",
 		Short: "This command helps debug the internal chart files",

--- a/pkg/debug/chart.go
+++ b/pkg/debug/chart.go
@@ -6,17 +6,18 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"fmt"
-	"github.com/spf13/cobra"
 	"io"
 	"os"
 	"path/filepath"
+
+	"github.com/spf13/cobra"
 )
 
 func ChartDebugSubCommand(base64ChartTarball string) *cobra.Command {
 	return &cobra.Command{
 		Use:   "debug-chart",
 		Short: "This command helps debug the internal chart files",
-		Run: func(cmd *cobra.Command, args []string) {
+		Run: func(_ *cobra.Command, _ []string) {
 			fmt.Println("TODO debug")
 			// TODO: use straing data from base64ChartTarball to:
 			// Un-base64 the data to get a raw tgz file,


### PR DESCRIPTION
Per title, this PR adds method to debug the embedded chart inside of PromFed.
It's a lot easier to exec into the pod and run:
```
cd /tmp
prometheus-federator debug-chart
```

Which will save the chart to the `${CWD}/.debug` folder.