### PR TITLE
Improve build process for VEXing

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -30,7 +30,7 @@ jobs:
           helm version
           rm get_helm.sh
       - name: Package helm chart
-        run : ./scripts/build-chart
+        run : ./scripts/build-chart && BUILD_TARGET=helm-project-operator ./scripts/build-chart
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
         with:

--- a/cmd/helm-locker/main.go
+++ b/cmd/helm-locker/main.go
@@ -1,5 +1,3 @@
-//go:build helm_locker
-
 package main
 
 import (

--- a/cmd/helm-project-operator/main.go
+++ b/cmd/helm-project-operator/main.go
@@ -1,5 +1,3 @@
-//go:build helm_project_operator
-
 package main
 
 import (

--- a/cmd/helm-project-operator/main.go
+++ b/cmd/helm-project-operator/main.go
@@ -34,7 +34,7 @@ var (
 	base64TgzChart string
 
 	debugConfig command.DebugConfig
-	updateCRDs  bool = false
+	updateCRDs  = false
 )
 
 type DummyOperator struct {

--- a/cmd/prometheus-federator/main.go
+++ b/cmd/prometheus-federator/main.go
@@ -1,5 +1,3 @@
-//go:build prometheus_federator
-
 package main
 
 import (

--- a/cmd/prometheus-federator/main.go
+++ b/cmd/prometheus-federator/main.go
@@ -35,7 +35,7 @@ var (
 	base64TgzChart string
 
 	debugConfig command.DebugConfig
-	updateCRDs  bool = false
+	updateCRDs  = false
 )
 
 type PrometheusFederator struct {

--- a/scripts/build
+++ b/scripts/build
@@ -2,7 +2,7 @@
 set -e
 
 source $(dirname $0)/version
-BUILD_CMD_TARGET=${BUILD_CMD_TARGET:-"./cmd/${BUILD_TARGET}/main.go"}
+BUILD_CMD_TARGET=${BUILD_CMD_TARGET:-"./cmd/${BUILD_TARGET}/"}
 
 cd $(dirname $0)/..
 

--- a/scripts/test
+++ b/scripts/test
@@ -6,7 +6,10 @@ cd $(dirname $0)/..
 
 echo "Starating tests"
 
-TARGET_TEST_TAG="${BUILD_TARGET/-/_}"
+echo "Running tests for ${BUILD_TARGET}"
 
-echo "Running tests for ${TARGET_TEST_TAG}"
-go test -cover -tags="test,${TARGET_TEST_TAG}" ./...
+PKG_LIST=$(go list "./cmd/${BUILD_TARGET}/...")
+ALL_PKG_LIST=$(go list ./pkg/...)
+COMBINED_LIST="$PKG_LIST $ALL_PKG_LIST"
+
+go test -cover $COMBINED_LIST

--- a/scripts/validate
+++ b/scripts/validate
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
 set -e
 
+source $(dirname $0)/version
 cd $(dirname $0)/..
 
 echo "Running validation"
 
+echo "Collecting packages to validate for target: ${BUILD_TARGET}"
 PKG_LIST=$(go list "./cmd/${BUILD_TARGET}/...")
 ALL_PKG_LIST=$(go list ./pkg/...)
 COMBINED_LIST="$PKG_LIST $ALL_PKG_LIST"
 
-echo Running: go fmt
+echo "Running: go fmt"
 test -z "$(go fmt ${COMBINED_LIST} | tee /dev/stderr)"
 echo "Validate passed"

--- a/scripts/validate
+++ b/scripts/validate
@@ -4,7 +4,11 @@ set -e
 cd $(dirname $0)/..
 
 echo "Running validation"
-PACKAGES="$(go list ./...)"
+
+PKG_LIST=$(go list "./cmd/${BUILD_TARGET}/...")
+ALL_PKG_LIST=$(go list ./pkg/...)
+COMBINED_LIST="$PKG_LIST $ALL_PKG_LIST"
+
 echo Running: go fmt
-test -z "$(go fmt ${PACKAGES} | tee /dev/stderr)"
+test -z "$(go fmt ${COMBINED_LIST} | tee /dev/stderr)"
 echo "Validate passed"


### PR DESCRIPTION
Before:
```
 → go version -m ./build/bin/prometheus-federator|head -2
./build/bin/prometheus-federator: go1.23.4
        path    command-line-arguments
```

After:
```
 → go version -m ./build/bin/prometheus-federator|head -2
./build/bin/prometheus-federator: go1.23.4
        path    github.com/rancher/prometheus-federator/cmd/prometheus-federator
```

---

Note that in the process of removing tags to improve VEX support we noticed that tags were also preventing some code from being linted. Specifically the `cmd` files were excluded. After the change they are included, so these additional commits to fix those changes were necessary.