### PR TITLE
[SURE-9656] Prometheus Federator controller restarts breaks the rolebinding sync

### DIFF
--- a/internal/helm-project-operator/controllers/project/controller.go
+++ b/internal/helm-project-operator/controllers/project/controller.go
@@ -104,7 +104,7 @@ func Register(
 		projectGetter:           projectGetter,
 	}
 
-	h.initIndexers()
+	h.initIndexers(ctx)
 
 	h.initResolvers(ctx)
 


### PR DESCRIPTION
Related Issue: https://github.com/rancher/rancher/issues/48985
### Checklist

Please fill out this table to identify which fields need to be modified in your PR.

**Under `Status`, either indicate `Does Not Apply` or `Added to this PR`**.

| **Version to be incremented**                                              | Why should this be modified?                                                                                                           | Status                                      |
|-----------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------|
| `version` in rancher-project-monitoring `package.yaml`                  | You modified the contents of the `rancher-project-monitoring` chart to make changes                                                    |  |
| `helmProjectOperator.image.tag` in prometheus-federator `values.yaml` | Either you modified the rancher-project-monitoring chart or you modified the `main.go` file                                          |  |
| `appVersion` in prometheus-federator `Chart.yaml`                     | You modified the `helmProjectOperator.image.tag` in the above box                                                                      |  |
| `version` in prometheus-federator `Chart.yaml`                        | Either you modified the `appVersion` in the above box or you modified the contents of the `prometheus-federator` chart to make changes |  |

