### PR TITLE
fix(ci): Correct k3s version used for e2e testing

### DIFF
--- a/.github/workflows/hl-e2e.yaml
+++ b/.github/workflows/hl-e2e.yaml
@@ -48,10 +48,8 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${{ matrix.arch == 'x64' && 'amd64' || matrix.arch  }} -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
       - name: Set K3S Min/Max Versions
-        id: set-vars
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        id: set-vars
         run: echo "K3S_VERSION=$K3S_MIN_VERSION" >> $GITHUB_ENV
       - name: build
         run: BUILD_TARGET=helm-locker make build

--- a/.github/workflows/hl-e2e.yaml
+++ b/.github/workflows/hl-e2e.yaml
@@ -36,12 +36,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set K3S Min/Max Versions
-        id: set-vars
-        run: bash ./scripts/k3s-version >> $GITHUB_ENV
-      - name: Set K3S_VERSION
-        id: set-vars
-        run: echo "K3S_VERSION=$K3S_MIN_VERSION" >> $GITHUB_ENV
       - name : Set up Go
         uses : actions/setup-go@v5
         with:
@@ -50,6 +44,15 @@ jobs:
       - uses: azure/setup-helm@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install mikefarah/yq
+        run: |
+          sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${{ matrix.arch == 'x64' && 'amd64' || matrix.arch  }} -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=$K3S_MIN_VERSION" >> $GITHUB_ENV
       - name: build
         run: BUILD_TARGET=helm-locker make build
       - name : Install k3d

--- a/.github/workflows/hl-e2e.yaml
+++ b/.github/workflows/hl-e2e.yaml
@@ -23,7 +23,6 @@ on:
 
 env:
   CLUSTER_NAME : e2e-ci-helm-locker
-  K3S_VERSION : v1.27.9-k3s1
 
 jobs:
   build:
@@ -37,6 +36,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=$K3S_MIN_VERSION" >> $GITHUB_ENV
       - name : Set up Go
         uses : actions/setup-go@v5
         with:

--- a/.github/workflows/hl-e2e.yaml
+++ b/.github/workflows/hl-e2e.yaml
@@ -51,7 +51,7 @@ jobs:
       - name: Set K3S Min/Max Versions
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        run: echo "K3S_VERSION=$K3S_MIN_VERSION" >> $GITHUB_ENV
+        run: echo "K3S_VERSION=$K3S_MIN_VERSION_TAG" >> $GITHUB_ENV
       - name: build
         run: BUILD_TARGET=helm-locker make build
       - name : Install k3d

--- a/.github/workflows/hl-e2e.yaml
+++ b/.github/workflows/hl-e2e.yaml
@@ -23,6 +23,7 @@ on:
 
 env:
   CLUSTER_NAME : e2e-ci-helm-locker
+  YQ_VERSION: v4.25.1
 
 jobs:
   build:

--- a/.github/workflows/hpo-e2e-ci.yaml
+++ b/.github/workflows/hpo-e2e-ci.yaml
@@ -43,9 +43,6 @@ jobs:
         arch:
           - x64
           - arm64
-        k3s_version:
-          # k3d version list k3s | sed 's/+/-/' | sort -h
-          - ${{ github.event.inputs.k3s_version || 'v1.27.9-k3s1' }}
     runs-on : runs-on,image=ubuntu22-full-${{ matrix.arch }},runner=4cpu-linux-${{ matrix.arch }},run-id=${{ github.run_id }}
     env:
       K3S_VERSION: ${{ matrix.k3s_version }}
@@ -53,6 +50,12 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - name : setup Go
         uses : actions/setup-go@v5
         with:
@@ -67,7 +70,7 @@ jobs:
       - name : Install k3d
         run : ./.github/workflows/e2e/scripts/install-k3d.sh
       - name : Setup k3d cluster
-        run : K3S_VERSION=${{ env.K3S_VERSION }} ./.github/workflows/e2e/scripts/setup-cluster.sh
+        run : ./.github/workflows/e2e/scripts/setup-cluster.sh
       - name: Import Images Into k3d
         run: |
           k3d image import ${REPO}/helm-project-operator:${TAG} -c "$CLUSTER_NAME";

--- a/.github/workflows/hpo-e2e-ci.yaml
+++ b/.github/workflows/hpo-e2e-ci.yaml
@@ -58,10 +58,8 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${{ matrix.arch == 'x64' && 'amd64' || matrix.arch  }} -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
       - name: Set K3S Min/Max Versions
-        id: set-vars
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        id: set-vars
         run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - name: Perform pre-e2e image build
         run: |

--- a/.github/workflows/hpo-e2e-ci.yaml
+++ b/.github/workflows/hpo-e2e-ci.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Set K3S Min/Max Versions
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION_TAG }}" >> $GITHUB_ENV
       - name: Perform pre-e2e image build
         run: |
           BUILD_TARGET=helm-project-operator REPO=${REPO} TAG=${TAG} ./scripts/build;

--- a/.github/workflows/hpo-e2e-ci.yaml
+++ b/.github/workflows/hpo-e2e-ci.yaml
@@ -50,12 +50,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set K3S Min/Max Versions
-        id: set-vars
-        run: bash ./scripts/k3s-version >> $GITHUB_ENV
-      - name: Set K3S_VERSION
-        id: set-vars
-        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - name : setup Go
         uses : actions/setup-go@v5
         with:
@@ -63,6 +57,12 @@ jobs:
       - name: Install mikefarah/yq
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${{ matrix.arch == 'x64' && 'amd64' || matrix.arch  }} -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - name: Perform pre-e2e image build
         run: |
           BUILD_TARGET=helm-project-operator REPO=${REPO} TAG=${TAG} ./scripts/build;

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Set K3S Min/Max Versions
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION_TAG }}" >> $GITHUB_ENV
       -
         name: Perform pre-e2e image build
         run: |

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -58,12 +58,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Set K3S Min/Max Versions
-        id: set-vars
-        run: bash ./scripts/k3s-version >> $GITHUB_ENV
-      - name: Set K3S_VERSION
-        id: set-vars
-        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.20.0'
@@ -80,6 +74,12 @@ jobs:
           source ./scripts/version
           echo TAG=$TAG >> $GITHUB_ENV
           echo IMAGE=$IMAGE >> $GITHUB_ENV
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       -
         name: Perform pre-e2e image build
         run: |

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -75,10 +75,8 @@ jobs:
           echo TAG=$TAG >> $GITHUB_ENV
           echo IMAGE=$IMAGE >> $GITHUB_ENV
       - name: Set K3S Min/Max Versions
-        id: set-vars
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION
-        id: set-vars
         run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       -
         name: Perform pre-e2e image build

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -52,15 +52,18 @@ jobs:
         arch:
           - x64
           - arm64
-        k3s_version:
-          # k3d version list k3s | sed 's/+/-/' | sort -h
-          - ${{ github.event.inputs.k3s_version || 'v1.28.14-k3s1' }}
     runs-on : runs-on,image=ubuntu22-full-${{ matrix.arch }},runner=4cpu-linux-${{ matrix.arch }},run-id=${{ github.run_id }}
     steps:
       -
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set K3S Min/Max Versions
+        id: set-vars
+        run: bash ./scripts/k3s-version >> $GITHUB_ENV
+      - name: Set K3S_VERSION
+        id: set-vars
+        run: echo "K3S_VERSION=${{ inputs.k3s_version || env.K3S_MIN_VERSION }}" >> $GITHUB_ENV
       - uses: actions/setup-go@v4
         with:
           go-version: '>=1.20.0'
@@ -87,7 +90,7 @@ jobs:
         run : ./.github/workflows/e2e/scripts/install-k3d.sh
       -
         name : Setup k3d cluster
-        run : K3S_VERSION=${{ matrix.k3s_version }} ./.github/workflows/e2e/scripts/setup-cluster.sh
+        run : ./.github/workflows/e2e/scripts/setup-cluster.sh
       -
         name: Import Images Into k3d
         run: |

--- a/build.yaml
+++ b/build.yaml
@@ -1,1 +1,3 @@
 rancherProjectMonitoringVersion: 0.3.4
+k3sTestingMaxVersion: v1.32.1+k3s1
+k3sTestingMinVersion: v1.30.9+k3s1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -3,5 +3,7 @@
 package buildconfig
 
 const (
+	K3sTestingMaxVersion            = "v1.32.1+k3s1"
+	K3sTestingMinVersion            = "v1.30.9+k3s1"
 	RancherProjectMonitoringVersion = "0.3.4"
 )

--- a/scripts/k3s-version
+++ b/scripts/k3s-version
@@ -10,6 +10,8 @@ export K3S_MIN_VERSION=$(yq '.k3sTestingMinVersion' $BUILD_YAML)
 
 function print_version_debug() {
     echo "K3S_MAX_VERSION=$K3S_MAX_VERSION"
+    echo "K3S_MAX_VERSION_TAG=${K3S_MAX_VERSION/+/-}"
     echo "K3S_MIN_VERSION=$K3S_MIN_VERSION"
+    echo "K3S_MIN_VERSION_TAG=${K3S_MIN_VERSION/+/-}"
 }
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then print_version_debug "$1"; fi

--- a/scripts/k3s-version
+++ b/scripts/k3s-version
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+
+SCRIPT_PATH="$(realpath ${BASH_SOURCE[0]})"
+PROJECT_ROOT="$(dirname $(dirname $SCRIPT_PATH))"
+BUILD_YAML="$PROJECT_ROOT/build.yaml"
+
+export K3S_MAX_VERSION=$(yq '.k3sTestingMaxVersion' $BUILD_YAML)
+export K3S_MIN_VERSION=$(yq '.k3sTestingMinVersion' $BUILD_YAML)
+
+function print_version_debug() {
+    echo "K3S_MAX_VERSION: $K3S_MAX_VERSION"
+    echo "K3S_MIN_VERSION: $K3S_MIN_VERSION"
+}
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then print_version_debug "$1"; fi

--- a/scripts/k3s-version
+++ b/scripts/k3s-version
@@ -9,7 +9,7 @@ export K3S_MAX_VERSION=$(yq '.k3sTestingMaxVersion' $BUILD_YAML)
 export K3S_MIN_VERSION=$(yq '.k3sTestingMinVersion' $BUILD_YAML)
 
 function print_version_debug() {
-    echo "K3S_MAX_VERSION: $K3S_MAX_VERSION"
-    echo "K3S_MIN_VERSION: $K3S_MIN_VERSION"
+    echo "K3S_MAX_VERSION=$K3S_MAX_VERSION"
+    echo "K3S_MIN_VERSION=$K3S_MIN_VERSION"
 }
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then print_version_debug "$1"; fi

--- a/scripts/local-e2e
+++ b/scripts/local-e2e
@@ -38,7 +38,7 @@ cd "$(dirname "$0")/.."
 # Setup CI specific Vars
 export CLUSTER_NAME='e2e-ci-prometheus-federator'
 export E2E_CI=true
-export K3S_VERSION=${K3S_VERSION:-${K3S_MIN_VERSION/+/-}}
+export K3S_VERSION=${K3S_VERSION:-$K3S_MIN_VERSION_TAG}
 
 if k3d cluster list $CLUSTER_NAME 2> /dev/null; then
   echo "The test cluster '$CLUSTER_NAME' already exists for some reason"

--- a/scripts/local-e2e
+++ b/scripts/local-e2e
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-DONT_CLEAN=false
+DONT_CLEAN=${DONT_CLEAN:-false}
 
 header() {
   local text="$1"
@@ -22,7 +22,7 @@ cleanupTest() {
 }
 
 onExit() {
-  if [[ "$?" -eq 0 ]]; then
+  if [[ "$?" -eq 0 ]] || [ "$DONT_CLEAN" == true ]; then
     exit 0
   fi
 
@@ -30,14 +30,15 @@ onExit() {
 }
 trap onExit EXIT
 
-source $(dirname $0)/version
+source "$(dirname "$0")/version"
+source "$(dirname "$0")/k3s-version"
 
-cd $(dirname $0)/..
+cd "$(dirname "$0")/.."
 
 # Setup CI specific Vars
 export CLUSTER_NAME='e2e-ci-prometheus-federator'
 export E2E_CI=true
-export K3S_VERSION=${K3S_VERSION:-v1.28.14-k3s1}
+export K3S_VERSION=${K3S_VERSION:-${K3S_MIN_VERSION/+/-}}
 
 if k3d cluster list $CLUSTER_NAME 2> /dev/null; then
   echo "The test cluster '$CLUSTER_NAME' already exists for some reason"
@@ -128,6 +129,13 @@ header "Validate Project Prometheus Alerts"
 header "Validate Project Alertmanager"
 ./.github/workflows/e2e/scripts/validate-project-alertmanager.sh;
 
+### ALL LOGIC ABOVE THIS
+if [ "$DONT_CLEAN" == true ]; then
+  header "Local e2e testing was a SUCCESS"
+  header "Exiting early, to leave cluster for testing"
+  exit;
+fi
+
 # Delete Project Prometheus Stack
 header "Delete Project Prometheus Stack"
 ./.github/workflows/e2e/scripts/delete-projecthelmchart.sh;
@@ -137,8 +145,4 @@ header "Uninstall Prometheus Federator"
 ./.github/workflows/e2e/scripts/uninstall-federator.sh;
 
 header "Local e2e testing was a SUCCESS"
-### ALL LOGIC ABOVE THIS
-if [ "$DONT_CLEAN" = true ]; then
-  exit;
-fi
 cleanupTest


### PR DESCRIPTION
Per title, this PR fixes an issue where the current k3s version used for e2e testing was static and with recent changes incompatible. So now we use a supported version for the k8s range we target with this version (based on the Rancher Minor we support).

Similarly, when we propagate changes back to other branches we will be able to set those branches to use proper k8s versions for e2e testing too.