### PR TITLE
feat (ci): pass in rancher monitoring version

### DIFF
--- a/.github/workflows/e2e/scripts/entry
+++ b/.github/workflows/e2e/scripts/entry
@@ -12,6 +12,12 @@ if [[ ${DEBUG} == "true" ]]; then
     set -x
 fi
 
+echo "Using rancher monitoring version : ${RANCHER_MONITORING}"
+
+if [ "$RANCHER_MONITORING" != "latest" ]; then
+    RANCHER_MONITORING_VERSION_HELM_ARGS="--version ${RANCHER_MONITORING}"
+fi
+
 if [[ "${E2E_CI}" == "true" ]]; then
     KUBERNETES_DISTRIBUTION_TYPE=k3s
 fi
@@ -23,9 +29,11 @@ if [[ -n ${RANCHER_URL} ]] && [[ -n ${RANCHER_CLUSTER} ]] && [[ -n ${RANCHER_TOK
         API_SERVER_URL=${RANCHER_URL}
     fi 
     API_SERVER_CURL_AUTH_HEADERS="-k -H 'Authorization: Bearer ${RANCHER_TOKEN}'"
-    RANCHER_HELM_ARGS="--set global.cattle.url=${RANCHER_URL} --set global.cattle.clusterId=${RANCHER_CLUSTER}"
+    RANCHER_CLUSTER_HELM_ARGS="--set global.cattle.url=${RANCHER_URL} --set global.cattle.clusterId=${RANCHER_CLUSTER}"
 else
     kubectl proxy --port=${APISERVER_PORT:-8001} 2>/dev/null &
     API_SERVER_URL=http://localhost:${APISERVER_PORT:-8001}
     sleep 5
 fi
+
+RANCHER_HELM_ARGS="${RANCHER_CLUSTER_HELM_ARGS} ${RANCHER_MONITORING_VERSION_HELM_ARGS}"

--- a/.github/workflows/e2e/scripts/install-monitoring.sh
+++ b/.github/workflows/e2e/scripts/install-monitoring.sh
@@ -21,7 +21,7 @@ echo "Installing rancher monitoring crd with :\n"
 
 helm search repo ${HELM_REPO}/rancher-monitoring-crd --versions --max-col-width=0 | head -n 2
 
-helm upgrade --install --create-namespace -n cattle-monitoring-system rancher-monitoring-crd ${HELM_REPO}/rancher-monitoring-crd
+helm upgrade --install --create-namespace -n cattle-monitoring-system ${RANCHER_MONITORING_VERSION_HELM_ARGS} rancher-monitoring-crd ${HELM_REPO}/rancher-monitoring-crd
 
 if [[ "${E2E_CI}" == "true" ]]; then
     e2e_args="--set grafana.resources=null --set prometheus.prometheusSpec.resources=null --set alertmanager.alertmanagerSpec.resources=null"

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -88,6 +88,7 @@ jobs:
           source ./scripts/version
           echo TAG=$TAG >> $GITHUB_ENV
           echo IMAGE=$IMAGE >> $GITHUB_ENV
+          echo RANCHER_MONITORING=$RANCHER_MONITORING >> $GITHUB_ENV
       - name: Set K3S Min/Max Versions
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,4 @@
 rancherProjectMonitoringVersion: 0.5.1
+rancherMonitoringVersion : latest
 k3sTestingMaxVersion: v1.32.1+k3s1
 k3sTestingMinVersion: v1.30.9+k3s1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,5 +5,6 @@ package buildconfig
 const (
 	K3sTestingMaxVersion            = "v1.32.1+k3s1"
 	K3sTestingMinVersion            = "v1.30.9+k3s1"
+	RancherMonitoringVersion        = "latest"
 	RancherProjectMonitoringVersion = "0.5.1"
 )

--- a/scripts/version
+++ b/scripts/version
@@ -45,6 +45,7 @@ IMAGE=${IMAGE:-"$REPO/${BUILD_TARGET}:${TAG}"}
 ROOT_DIR=$(dirname "$(realpath "$(dirname "${BASH_SOURCE[0]}")")")
 BUILD_YAML_PATH="$ROOT_DIR/build.yaml"
 RANCHER_PROJECT_MONITORING=${RANCHER_PROJECT_MONITORING:-$(grep 'rancherProjectMonitoringVersion' "$BUILD_YAML_PATH"|cut -d: -f2|tr -d ' ')}
+RANCHER_MONITORING=${RANCHER_MONITORING:-$(grep 'rancherMonitoringVersion' "$BUILD_YAML_PATH"|cut -d: -f2|tr -d ' ')}
 
 function print_version_debug() {
     echo "DIRTY: $DIRTY"
@@ -56,5 +57,6 @@ function print_version_debug() {
     echo "IMAGE: $IMAGE";
     echo "BUILD_YAML_PATH: $BUILD_YAML_PATH"
     echo "RANCHER PROJECT MONITORING: $RANCHER_PROJECT_MONITORING"
+    echo "RANCHER MONITORING: $RANCHER_MONITORING"
 }
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then print_version_debug "$1"; fi


### PR DESCRIPTION
Specific project monitoring versions require specific rancher-monitoring versions, therefore we add a build.yaml constant to control which rancher-monitoring version gets passed into CI