### PR TITLE
[v3.x] General backports from main to 3.x branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,8 +19,12 @@
   ],
   "packageRules": [
     {
-      "matchBaseBranches" : ["main", "release/v3.x"],
+      "matchBaseBranches" : ["main"],
       "extends" : ["github>rancher/renovate-config:rancher-main#release"]
+    },
+    {
+      "matchBaseBranches" : ["release/v3.x"],
+      "extends" : ["github>rancher/renovate-config:rancher-2.11#release"]
     },
     {
       "matchBaseBranches" : ["release/v2.x"],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -8,16 +8,28 @@
     "main",
     "release/v3.x",
     "release/v2.x",
-    "release/v1.x",
-    "release/v0.x"
+    "release/v1.x"
   ],
   "enabledManagers": [
     "dockerfile",
     "github-actions",
     "helm-values",
-    "custom.regex"
+    "custom.regex",
+    "gomod"
   ],
   "packageRules": [
+    {
+      "matchBaseBranches" : ["main", "release/v3.x"],
+      "extends" : ["github>rancher/renovate-config:rancher-main#release"]
+    },
+    {
+      "matchBaseBranches" : ["release/v2.x"],
+      "extends" : ["github>rancher/renovate-config:rancher-2.10#release"]
+    },
+    {
+      "matchBaseBranches": ["release/v1.x"],
+      "extends" : ["github>rancher/renovate-config:rancher-2.9#release"]
+    },
     {
       "groupName": "GitHub Workflow Actions",
       "groupSlug": "gha-deps",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
       - name : Set up Go
-        uses: actions/setup-go@bfdd3570ce990073878bf10f6b2d79082de49492 # v2
+        uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version: '1.22'
       - name: Check if yq is installed
@@ -55,7 +55,7 @@ jobs:
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${{ matrix.arch == 'x64' && 'amd64' || matrix.arch  }} -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
       - name : Install helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run CI

--- a/.github/workflows/e2e/scripts/entry
+++ b/.github/workflows/e2e/scripts/entry
@@ -12,6 +12,12 @@ if [[ ${DEBUG} == "true" ]]; then
     set -x
 fi
 
+echo "Using rancher monitoring version : ${RANCHER_MONITORING}"
+
+if [ "$RANCHER_MONITORING" != "latest" ]; then
+    RANCHER_MONITORING_VERSION_HELM_ARGS="--version ${RANCHER_MONITORING}"
+fi
+
 if [[ "${E2E_CI}" == "true" ]]; then
     KUBERNETES_DISTRIBUTION_TYPE=k3s
 fi
@@ -23,9 +29,11 @@ if [[ -n ${RANCHER_URL} ]] && [[ -n ${RANCHER_CLUSTER} ]] && [[ -n ${RANCHER_TOK
         API_SERVER_URL=${RANCHER_URL}
     fi 
     API_SERVER_CURL_AUTH_HEADERS="-k -H 'Authorization: Bearer ${RANCHER_TOKEN}'"
-    RANCHER_HELM_ARGS="--set global.cattle.url=${RANCHER_URL} --set global.cattle.clusterId=${RANCHER_CLUSTER}"
+    RANCHER_CLUSTER_HELM_ARGS="--set global.cattle.url=${RANCHER_URL} --set global.cattle.clusterId=${RANCHER_CLUSTER}"
 else
     kubectl proxy --port=${APISERVER_PORT:-8001} 2>/dev/null &
     API_SERVER_URL=http://localhost:${APISERVER_PORT:-8001}
     sleep 5
 fi
+
+RANCHER_HELM_ARGS="${RANCHER_CLUSTER_HELM_ARGS} ${RANCHER_MONITORING_VERSION_HELM_ARGS}"

--- a/.github/workflows/e2e/scripts/install-monitoring.sh
+++ b/.github/workflows/e2e/scripts/install-monitoring.sh
@@ -21,7 +21,7 @@ echo "Installing rancher monitoring crd with :\n"
 
 helm search repo ${HELM_REPO}/rancher-monitoring-crd --versions --max-col-width=0 | head -n 2
 
-helm upgrade --install --create-namespace -n cattle-monitoring-system rancher-monitoring-crd ${HELM_REPO}/rancher-monitoring-crd
+helm upgrade --install --create-namespace -n cattle-monitoring-system ${RANCHER_MONITORING_VERSION_HELM_ARGS} rancher-monitoring-crd ${HELM_REPO}/rancher-monitoring-crd
 
 if [[ "${E2E_CI}" == "true" ]]; then
     e2e_args="--set grafana.resources=null --set prometheus.prometheusSpec.resources=null --set alertmanager.alertmanagerSpec.resources=null"

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -45,7 +45,7 @@ jobs:
       with:
         go-version: 1.23
     - name : Install helm
-      uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+      uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: Set up Docker Buildx

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           go-version: '1.22'
       - name : Install helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Package helm chart

--- a/.github/workflows/pr-debug-publish.yaml
+++ b/.github/workflows/pr-debug-publish.yaml
@@ -77,7 +77,7 @@ jobs:
             type=raw,value=pr-${{ github.event.inputs.pr_number }}-${{ needs.prepare_pr_info.outputs.head_sha_short }}
             type=raw,value=pr-${{ github.event.inputs.pr_number }}
       - name: Build Helm-Project-Operator image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: .
           file: ./package/Dockerfile-helm-project-operator
@@ -120,7 +120,7 @@ jobs:
             type=raw,value=pr-${{ github.event.inputs.pr_number }}-${{ needs.prepare_pr_info.outputs.head_sha_short }}
             type=raw,value=pr-${{ github.event.inputs.pr_number }}
       - name: Build prometheus-federator image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: .
           file: ./package/Dockerfile-prometheus-federator
@@ -141,7 +141,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Comment on PR with image details
-        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7
         env:
           # meta-helm-locker: ${{ needs.build_dev_helm_locker.outputs.tags }}
           meta-helm-project-operator: ${{ needs.build_dev_helm_project_operator.outputs.tags }}

--- a/.github/workflows/prom-fed-e2e-ci.yaml
+++ b/.github/workflows/prom-fed-e2e-ci.yaml
@@ -59,12 +59,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
+      - uses: actions/setup-go@0aaccfd150d50ccaeb58ebd88d36e91967a5f35b # v5
         with:
           go-version: '>=1.20.0'
       - uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4
       - name : Install helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Check if yq is installed
@@ -88,6 +88,7 @@ jobs:
           source ./scripts/version
           echo TAG=$TAG >> $GITHUB_ENV
           echo IMAGE=$IMAGE >> $GITHUB_ENV
+          echo RANCHER_MONITORING=$RANCHER_MONITORING >> $GITHUB_ENV
       - name: Set K3S Min/Max Versions
         run: bash ./scripts/k3s-version >> $GITHUB_ENV
       - name: Set K3S_VERSION

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -51,9 +51,9 @@ jobs:
         if: steps.check_yq.outputs.install_yq == 'true'
         run: |
           sudo wget https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64 -O /usr/bin/yq && sudo chmod +x /usr/bin/yq;
-      - uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
+      - uses: azure/setup-kubectl@3e0aec4d80787158d308d7b364cb1b702e7feb7f # v4
       - name : Install helm
-        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
+        uses: azure/setup-helm@b9e51907a09c216f16ebe8536097933489208112 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Prepare helm charts (needed for build)
@@ -97,7 +97,7 @@ jobs:
         with:
           images: ${{ env.GHCR_REGISTRY }}/${{ env.IMAGE_NAME }}/helm-project-operator
       - name: Build Helm-Project-Operator image
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: .
           file: ./package/Dockerfile-helm-project-operator
@@ -144,7 +144,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3 
       - name: Build Prometheus Federator image 
-        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6
         with:
           context: .
           file: ./package/Dockerfile-prometheus-federator

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -11,7 +11,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da # v4
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9
         with:
           stale-issue-message: 'This repository uses an automated workflow to automatically label issues which have not had any activity (commit/comment/label) for 60 days. This helps us manage the community issues better. If the issue is still relevant, please add a comment to the issue so the workflow can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the latest release), the workflow will automatically close the issue in 14 days. Thank you for your contributions.'
           stale-pr-message: 'This repository uses an automated workflow to automatically label pull requests which have not had any activity (commit/comment/label) for 60 days. This helps us manage the community pull requests better. If the pull request is still relevant, please add a comment to the pull request so the workflow can remove the label and we know it is still valid. If it is no longer relevant (or possibly fixed in the latest release), the workflow will automatically close the pull request in 14 days. Thank you for your contributions.'

--- a/README.md
+++ b/README.md
@@ -21,15 +21,13 @@ For more information, see the [Getting Started guide](docs/prometheus-federator/
 ### Branches and Releases
 This is the current branch strategy for `rancher/prometheus-federator`, it may change in the future.
 
-| Branch         | Tag              | Rancher                |
-|----------------|------------------|------------------------|
-| `main` (v3.x)  | `head`, `v3.x.x` | `main` branch (`head`) |
-| `release/v1.x` | `v1.x.x`         | `v2.10.x`, `v2.9.x`    |
-| `release/v0.x` | `v0.x.x`         | Legacy Branch          |
-
-> [!NOTE]
-> We are still adopting our new Branch strategy. Soon all Rancher Minors will have a branch targeting them.
-> When a Branch for v2.x is created 2.10 will be updated to use that rather than v1.x.
+| Branch         | Tag      | Rancher                |
+|----------------|----------|------------------------|
+| `main`         | `head`   | `main` branch (`head`) |
+| `release/v3.x` | `v3.x.x` | `v2.11.x`              |
+| `release/v2.x` | `v2.x.x` | `v2.10.x`              |
+| `release/v1.x` | `v1.x.x` | `v2.9.x`               |
+| `release/v0.x` | `v0.x.x` | Legacy Branch          |
 
 
 ## More Info

--- a/build.yaml
+++ b/build.yaml
@@ -1,3 +1,8 @@
 rancherProjectMonitoringVersion: 0.5.1
+rancherMonitoringVersion : latest
 k3sTestingMaxVersion: v1.32.1+k3s1
 k3sTestingMinVersion: v1.30.9+k3s1
+
+# Dev use only
+# devChartsSource: https://github.com/{Dev}/ob-team-charts
+# devChartsBranch: {your branch}

--- a/charts/prometheus-federator/templates/cleanup.yaml
+++ b/charts/prometheus-federator/templates/cleanup.yaml
@@ -55,12 +55,29 @@ spec:
           command:
           - /bin/sh
           - -c
-          - >
+          - |
+            echo "Checking if HelmCharts and HelmReleases CRDs exist...";
+            CRD_HELMCHARTS=$(kubectl get crd helmcharts.helm.cattle.io --ignore-not-found)
+            CRD_HELMRELEASES=$(kubectl get crd helmreleases.helm.cattle.io --ignore-not-found)
+            if [ -z "$CRD_HELMCHARTS" ] && [ -z "$CRD_HELMRELEASES" ]; then
+              echo "Neither HelmCharts nor HelmReleases CRDs exist in cluster, nothing to clean.";
+              exit 0;
+            fi
+            RESOURCE_LIST=""
+            if [ -n "$CRD_HELMCHARTS" ]; then
+              RESOURCE_LIST="helmcharts"
+            fi
+            if [ -n "$CRD_HELMRELEASES" ]; then
+              if [ -n "$RESOURCE_LIST" ]; then
+                RESOURCE_LIST="$RESOURCE_LIST,"
+              fi
+              RESOURCE_LIST="${RESOURCE_LIST}helmreleases"
+            fi
             SYSTEM_NAMESPACE={{ .Release.Namespace }}
             EXPECTED_HELM_API_VERSION={{ .Values.helmProjectOperator.helmApiVersion }};
             HELM_API_VERSION_TRUNCATED=$(echo ${EXPECTED_HELM_API_VERSION} | cut -d'/' -f0);
             echo "Ensuring HelmCharts and HelmReleases are deleted from ${SYSTEM_NAMESPACE}...";
-            while [[ "$(kubectl get helmcharts,helmreleases -l helm.cattle.io/helm-api-version=${HELM_API_VERSION_TRUNCATED} -n ${SYSTEM_NAMESPACE} 2>&1)" != "No resources found in ${SYSTEM_NAMESPACE} namespace." ]]; do
+            while [[ "$(kubectl get ${RESOURCE_LIST} -l helm.cattle.io/helm-api-version=${HELM_API_VERSION_TRUNCATED} -n ${SYSTEM_NAMESPACE} 2>&1)" != "No resources found in ${SYSTEM_NAMESPACE} namespace." ]]; do
               echo "waiting for HelmCharts and HelmReleases to be deleted from ${SYSTEM_NAMESPACE}... sleeping 3 seconds";
               sleep 3;
             done;

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -5,5 +5,6 @@ package buildconfig
 const (
 	K3sTestingMaxVersion            = "v1.32.1+k3s1"
 	K3sTestingMinVersion            = "v1.30.9+k3s1"
+	RancherMonitoringVersion        = "latest"
 	RancherProjectMonitoringVersion = "0.5.1"
 )

--- a/scripts/util-team-charts
+++ b/scripts/util-team-charts
@@ -1,7 +1,21 @@
 #!/usr/bin/env bash
+set -x
+
+
+CHARTS_REPO="https://raw.githubusercontent.com/rancher/ob-team-charts"
+CHARTS_BRANCH="main"
+
+if grep -v "^#" "$BUILD_YAML_PATH"| grep 'devChartsSource'; then
+  TMP_CHARTS_REPO=$(grep 'devChartsSource' "$BUILD_YAML_PATH"|cut -d" " -f2|tr -d ' ')
+  CHARTS_REPO=$(echo "$TMP_CHARTS_REPO" | sed 's/github\.com/raw\.githubusercontent\.com/g')
+fi
+if grep -v "^#" "$BUILD_YAML_PATH"| grep 'devChartsBranch'; then
+  CHARTS_BRANCH=$(grep 'devChartsBranch' "$BUILD_YAML_PATH"|cut -d: -f2|tr -d ' ')
+fi
+
 
 function fetch-team-charts-index() {
-  TEAM_INDEX="https://raw.githubusercontent.com/rancher/ob-team-charts/refs/heads/main/index.yaml"
+  TEAM_INDEX="$CHARTS_REPO/refs/heads/$CHARTS_BRANCH/index.yaml"
   BUILD_DIR="./build"
   LOCAL_FILE="$BUILD_DIR/charts-index.yaml"
   LOCAL_ETAG_FILE="$BUILD_DIR/charts-index.etag"
@@ -49,7 +63,7 @@ function newest-chart-version() {
 
 function fetch-team-chart() {
   CHART_TARGET="${1}"
-  BASE_FETCH_URL="https://raw.githubusercontent.com/rancher/ob-team-charts/refs/heads/main/assets"
+  BASE_FETCH_URL="$CHARTS_REPO/refs/heads/$CHARTS_BRANCH/assets"
   CHART_VERSION="${2}"
   FETCH_URL="${BASE_FETCH_URL}/${CHART_TARGET}/${CHART_TARGET}-${CHART_VERSION}.tgz"
   echo "Fetching version $CHART_VERSION of $CHART_TARGET"

--- a/scripts/version
+++ b/scripts/version
@@ -45,6 +45,7 @@ IMAGE=${IMAGE:-"$REPO/${BUILD_TARGET}:${TAG}"}
 ROOT_DIR=$(dirname "$(realpath "$(dirname "${BASH_SOURCE[0]}")")")
 BUILD_YAML_PATH="$ROOT_DIR/build.yaml"
 RANCHER_PROJECT_MONITORING=${RANCHER_PROJECT_MONITORING:-$(grep 'rancherProjectMonitoringVersion' "$BUILD_YAML_PATH"|cut -d: -f2|tr -d ' ')}
+RANCHER_MONITORING=${RANCHER_MONITORING:-$(grep 'rancherMonitoringVersion' "$BUILD_YAML_PATH"|cut -d: -f2|tr -d ' ')}
 
 function print_version_debug() {
     echo "DIRTY: $DIRTY"
@@ -56,5 +57,6 @@ function print_version_debug() {
     echo "IMAGE: $IMAGE";
     echo "BUILD_YAML_PATH: $BUILD_YAML_PATH"
     echo "RANCHER PROJECT MONITORING: $RANCHER_PROJECT_MONITORING"
+    echo "RANCHER MONITORING: $RANCHER_MONITORING"
 }
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then print_version_debug "$1"; fi


### PR DESCRIPTION
This covers general CI improvements we've added to main as well as: https://github.com/rancher/prometheus-federator/pull/194

This catches up the 3.x branch with main so that when we tag a consecutive 3.x RC for @jbiers work it will make sense since I overlooked this branch and tagged directly on main.