### PR TITLE
ci: Adjust renovate branch rules for 3.x branch

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -19,8 +19,12 @@
   ],
   "packageRules": [
     {
-      "matchBaseBranches" : ["main", "release/v3.x"],
+      "matchBaseBranches" : ["main"],
       "extends" : ["github>rancher/renovate-config:rancher-main#release"]
+    },
+    {
+      "matchBaseBranches" : ["release/v3.x"],
+      "extends" : ["github>rancher/renovate-config:rancher-2.11#release"]
     },
     {
       "matchBaseBranches" : ["release/v2.x"],


### PR DESCRIPTION
Per title, this fixes the rules so that 3.x branch uses the correct renovate branch config.