### PR TITLE
fix (dev) : adjust helm chart version to use build metadata to encode…

### DIFF
--- a/scripts/version
+++ b/scripts/version
@@ -29,7 +29,7 @@ REPO=${REPO:-rancher}
 
 HELM_IMAGE_TAG=${HELM_IMAGE_TAG:-${TAG}}
 if [ "$TAG" == "$COMMIT" ]; then
-  HELM_CHART_VERSION="0.0.0-dev.${COMMIT}"
+  HELM_CHART_VERSION="0.0.0-dev+${COMMIT}"
 else
   HELM_CHART_VERSION=${HELM_IMAGE_TAG/v/}
 fi


### PR DESCRIPTION
## Problem

CI will occasionally fail due to not constructing a valid semver constraint on the dev helm chart version : [Example](https://github.com/rancher/prometheus-federator/actions/runs/14365850845/job/40280151176?pr=247)
If a git commit sha starts with 0, the constructed dev helm version will become:
```
0.0.0-dev.0<rest-of-commit>
```

and semver disallows a 0 prefix for a prerelease number that is not exactly 0. You can verify this [here](https://jubianchi.github.io/semver-check/#/constraint/0.0.0-dev.0123) or using :

```go
package main

import (
	"fmt"

	"github.com/Masterminds/semver/v3"
)

func main() {
       //always panics
	constraint, err := semver.NewConstraint("0.0.0-dev.0365158")
	if err != nil {
		panic(err)
	}
	fmt.Println(constraint)
}

```

## Fix

Switching to build metadata `0.0.0-dev+<commit>` will make any commit sha valid with semver constraints.

