### PR TITLE
[Backport] [v3.x] [SURE-9656] fix : prometheus Federator controller restarts breaks the rolebinding sync

### DIFF
--- a/internal/helm-project-operator/controllers/project/controller.go
+++ b/internal/helm-project-operator/controllers/project/controller.go
@@ -103,7 +103,7 @@ func Register(
 		projectGetter:           projectGetter,
 	}
 
-	h.initIndexers()
+	h.initIndexers(ctx)
 
 	h.initResolvers(ctx)
 


### PR DESCRIPTION
Part of : https://github.com/rancher/rancher/issues/48985

Backport of : https://github.com/rancher/prometheus-federator/pull/166
