### PR TITLE
fix(chart): correct Icon path to fix rancher/charts air-gap issue

### DIFF
--- a/charts/prometheus-federator/Chart.yaml
+++ b/charts/prometheus-federator/Chart.yaml
@@ -9,7 +9,7 @@ annotations:
 apiVersion: v2
 appVersion: 9999
 description: Prometheus Federator - installs rancher-project-monitoring in project namespaces.
-icon: https://raw.githubusercontent.com/rancher/prometheus-federator/main/assets/logos/prometheus-federator.svg
+icon: https://raw.githubusercontent.com/rancher/ob-team-charts/main/assets/logos/prometheus-federator.svg
 keywords:
   - prometheus
   - monitoring


### PR DESCRIPTION
Back when I was re-orging PromFed (and the related Go code projects) along with our monitoring charts I must have moved this file without realizing the other references that would need updating.