### PR TITLE
feat(chart) : allow end users to vendor a helm-controller deployment

### DIFF
--- a/charts/prometheus-federator/README.md
+++ b/charts/prometheus-federator/README.md
@@ -116,5 +116,24 @@ By default, the `rancher-project-monitoring` (the underlying chart deployed by P
 |`helmProjectOperator.releaseRoleBindings.clusterRoleRefs.<admin\|edit\|view>`| ClusterRoles to reference to discover subjects to create RoleBindings for in the Project Release Namespace for all corresponding Project Release Roles. See RBAC above for more information |
 |`helmProjectOperator.hardenedNamespaces.enabled`| Whether to automatically patch the default ServiceAccount with `automountServiceAccountToken: false` and create a default NetworkPolicy in all managed namespaces in the cluster; the default values ensure that the creation of the namespace does not break a CIS 1.16 hardened scan |
 |`helmProjectOperator.hardenedNamespaces.configuration`| The configuration to be supplied to the default ServiceAccount or auto-generated NetworkPolicy on managing a namespace |
-|`helmProjectOperator.helmController.enabled`| Whether to enable an embedded k3s-io/helm-controller instance within the Helm Project Operator. Should be disabled for RKE2/K3s clusters before v1.23.14 / v1.24.8 / v1.25.4 since RKE2/K3s clusters already run Helm Controller at a cluster-wide level to manage internal Kubernetes components |
+|`helmProjectOperator.helmController.enabled`| Whether to enable an embedded in process k3s-io/helm-controller instance within the Helm Project Operator. Should be disabled for RKE2/K3s clusters before v1.23.14 / v1.24.8 / v1.25.4 since RKE2/K3s clusters already run Helm Controller at a cluster-wide level to manage internal Kubernetes components |
 |`helmProjectOperator.helmLocker.enabled`| Whether to enable an embedded rancher/helm-locker instance within the Helm Project Operator. |
+
+### Advanced Vendored Helm Controller Configuration
+
+Prometheus Federator's underlying Helm Project Operator allows for running an embedded helm-controller in environments where it may not be readily available (usually Kubernetes distributions that are not `k3s` or `RKE2`).
+
+Another usecase for deploying a vendored helm controller is to scope the management of `HelmChart` CRs managed by prometheus federator to a specific helm-controller, and not the global one provided by `k3s` or `RKE2`, for example.
+
+However, it used to be only available with a specific version that is run in process via `helmProjectOperator.helmController.enabled` .
+
+running it as a deployment allows users to pin a specific version (and hence pin specific CRD versions for the operator) in order to prevent conflicts. and scale it up independently from prometheus-federator.
+
+|Value|Configuration|
+|---|---------------------------|
+| `helmProjectOperator.helmController.deployment.enabled` | When `helmProjectOperator.helmController.enabled` runs the vendored helm-controller as a deployment, as opposed to in process alongside prometheus-federator |
+| `helmProjectOperator.helmController.deployment.replicas` |  Scales the number of replicas for the helm-conttronller deployment |
+| `helmProjectOperator.helmController.deployment.registry` | Overrides the registry from which to pull the helm-controller container |
+| `helmProjectOperator.helmController.deployment.repository` | Overrides the repository from which to pull the helm-controller container |
+| `helmProjectOperator.helmController.deployment.tag` | Overrides the container tag for the helm-controller container |
+| `helmProjectOperator.helmController.deployment.pullPolicy` | Overrides the image pull policy for the helm-controller |

--- a/charts/prometheus-federator/templates/_helpers.tpl
+++ b/charts/prometheus-federator/templates/_helpers.tpl
@@ -5,6 +5,13 @@
 {{- end -}}
 {{- end -}}
 
+{{- define "helm-controller.imageRegistry" -}}
+{{- if and .Values.image .Values.image.registry }}{{- printf "%s/" .Values.image.registry -}}
+{{- else if .Values.helmProjectOperator.helmController.image.registry }}{{- printf "%s/" .Values.helmProjectOperator.helmController.image.registry -}}
+{{- else }}{{ template "system_default_registry" .  }}
+{{- end }}
+{{- end }}
+
 {{/* Define the image registry to use; either values, or systemdefault if set, or nothing */}}
 {{- define "prometheus-federator.imageRegistry" -}}
 {{- if and .Values.image .Values.image.registry }}{{- printf "%s/" .Values.image.registry -}}

--- a/charts/prometheus-federator/templates/deployment.yaml
+++ b/charts/prometheus-federator/templates/deployment.yaml
@@ -84,7 +84,7 @@ spec:
           - --debug
           - --debug-level={{ .Values.helmProjectOperator.debugLevel }}
 {{- end }}
-{{- if not .Values.helmProjectOperator.helmController.enabled }}
+{{- if and (not .Values.helmProjectOperator.helmController.enabled)  (.Values.helmProjectOperator.helmController.deployment.enabled) }}
           - --disable-embedded-helm-controller
 {{- else }}
           - --helm-job-image={{ template "system_default_registry" . }}{{ .Values.helmProjectOperator.helmController.job.image.repository }}:{{ .Values.helmProjectOperator.helmController.job.image.tag }}

--- a/charts/prometheus-federator/templates/helmcontroller.yaml
+++ b/charts/prometheus-federator/templates/helmcontroller.yaml
@@ -1,0 +1,36 @@
+{{- if and (.Values.helmProjectOperator.helmController.enabled) (.Values.helmProjectOperator.helmController.deployment.enabled) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: prometheus-federator-helm-controller
+  namespace: {{ template "prometheus-federator.namespace" . }}
+  labels:
+    app: prometheus-federator-helm-controller
+spec:
+  replicas: {{ .Values.helmProjectOperator.helmController.deployment.replicas }}
+  selector:
+    matchLabels:
+      app: prometheus-federator-helm-controller
+  template:
+    metadata:
+      labels:
+        app: prometheus-federator-helm-controller
+    spec:
+      # has to match cluster-admin service account
+      serviceAccountName : prometheus-federator-helm-controller
+      containers:
+      - name: helm-controller
+        image: {{ template "helm-controller.imageRegistry" . }} {{ .Values.helmProjectOperator.helmController.deployment.image.repository }}:{{ .Values.helmProjectOperator.helmController.deployment.image.tag }}
+        command: ["helm-controller"]
+        env:
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        # this sets the `managedBy` annotations, must match the ones in prometheus-federator
+        - name: JOB_CLUSTER_ROLE
+          value: {{ template "prometheus-federator.name" . }}
+        # this sets the `systemNamespace` for the helm-controller to watch, should match the one in prometheus-federator
+        - name: SYSTEM_NAMESPACE
+          value: {{ template "prometheus-federator.namespace" . }}
+{{ end }}

--- a/charts/prometheus-federator/templates/rbac.yaml
+++ b/charts/prometheus-federator/templates/rbac.yaml
@@ -30,3 +30,37 @@ imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 #
 # As a result, this ClusterRoleBinding will be left as a work-in-progress until changes are made in k3s-io/helm-controller to allow us to grant
 # only scoped down permissions to the Job that is deployed.
+{{- if and (.Values.helmProjectOperator.helmController.enabled) (.Values.helmProjectOperator.helmController.deployment.enabled) }}
+# this authorizations have to match cluster-admin service account
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: prometheus-federator-helm-controller
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - "*"
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-federator-helm-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-federator-helm-controller
+subjects:
+- kind: ServiceAccount
+  name: prometheus-federator-helm-controller
+  namespace: {{ template "prometheus-federator.namespace" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-federator-helm-controller
+  namespace: {{ template "prometheus-federator.namespace" . }}
+{{- end}}

--- a/charts/prometheus-federator/values.yaml
+++ b/charts/prometheus-federator/values.yaml
@@ -149,6 +149,13 @@ helmProjectOperator:
   helmController:
     # Note: should be disabled for RKE2 clusters since they already run Helm Controller to manage internal Kubernetes components
     enabled: true
+    deployment:
+      enabled : false
+      replicas : 1
+      image:
+        repository: rancher/helm-controller
+        tag: v0.16.10
+        pullPolicy: IfNotPresent
 
     job:
       image:

--- a/internal/helm-project-operator/controllers/controllers.go
+++ b/internal/helm-project-operator/controllers/controllers.go
@@ -190,6 +190,7 @@ func Register(ctx context.Context, systemNamespace string, cfg clientcmd.ClientC
 		logrus.Infof("Registering embedded Helm Controller...")
 		chart.Register(ctx,
 			systemNamespace,
+			// this corresponds to the managedBy annotation for helm charts
 			opts.ControllerName,
 			// this has to be cluster-admin for k3s reasons
 			"cluster-admin",


### PR DESCRIPTION
Used to scope management of promfed HelmChart CRs to a specific helm-controller deployment.

Related Issue:  Part of https://github.com/rancher/prometheus-federator/issues/148

## Testing Considerations

Example values.yaml:
```yaml
    enabled: true
    deployment:
      enabled : true
      replicas : 1
      image:
        repository: rancher/helm-controller
        tag: v0.16.10
        pullPolicy: IfNotPresent
```

or via CLI `--set helmProjectOperator.helmController.deployment.enabled=true`

TODO: Test Setup & Expected behaviour: 🔴 🔴🔴

