### PR TITLE
bump RPM to 0.6.7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-rancherProjectMonitoringVersion: 0.6.6
+rancherProjectMonitoringVersion: 0.6.7
 rancherMonitoringVersion : latest
 k3sTestingMaxVersion: v1.33.1+k3s1
 k3sTestingMinVersion: v1.31.9+k3s1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	K3sTestingMinVersion            = "v1.31.9+k3s1"
 	KuberlrVersion                  = "v5"
 	RancherMonitoringVersion        = "latest"
-	RancherProjectMonitoringVersion = "0.6.6"
+	RancherProjectMonitoringVersion = "0.6.7"
 )


### PR DESCRIPTION
This syncs in the new RPM version from: https://github.com/rancher/ob-team-charts/pull/145