### PR TITLE
[v3.x/v2.11] bump RPM to 0.6.7

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,4 +1,4 @@
-rancherProjectMonitoringVersion: 0.6.1
+rancherProjectMonitoringVersion: 0.6.7
 rancherMonitoringVersion : latest
 k3sTestingMaxVersion: v1.32.1+k3s1
 k3sTestingMinVersion: v1.30.9+k3s1

--- a/pkg/buildconfig/constants.go
+++ b/pkg/buildconfig/constants.go
@@ -7,5 +7,5 @@ const (
 	K3sTestingMinVersion            = "v1.30.9+k3s1"
 	KuberlrVersion                  = "v4"
 	RancherMonitoringVersion        = "latest"
-	RancherProjectMonitoringVersion = "0.6.1"
+	RancherProjectMonitoringVersion = "0.6.7"
 )


### PR DESCRIPTION
This syncs in the new RPM version from: https://github.com/rancher/ob-team-charts/pull/145