### PR TITLE
fix publish GHA

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,6 +141,7 @@ jobs:
         with:
           image: ${{ env.IMAGE_NAME }}
           tag: ${{ github.ref_name }}
+          identity-registry: ${{ env.PRIME_STG_REGISTRY }}
 
           public-registry: ${{ env.PUBLIC_REGISTRY }}
           public-repo: ${{ env.REPO }}
@@ -152,4 +153,3 @@ jobs:
           prime-repo: ${{ env.REPO }}
           prime-username: ${{ env.PRIME_STG_REGISTRY_USERNAME }}
           prime-password: ${{ env.PRIME_STG_REGISTRY_PASSWORD }}
-          identity-registry: ${{ env.PRIME_REGISTRY }}


### PR DESCRIPTION
Issue: https://github.com/rancher/prometheus-federator/issues/326

This PR corrects the GHA file name & points `identity-registry` to Staging Registry.