### PR TITLE
[2.13] Replace kuberlr image on build

### DIFF
--- a/charts/prometheus-federator/values.yaml
+++ b/charts/prometheus-federator/values.yaml
@@ -210,7 +210,7 @@ helmProjectOperator:
   cleanup:
     image:
       repository: rancher/kuberlr-kubectl
-      tag: v6.0.0
+      tag: 9999
       pullPolicy: IfNotPresent
 
     ## Define which Nodes the Pods are scheduled on.

--- a/scripts/package-helm
+++ b/scripts/package-helm
@@ -6,9 +6,15 @@ if ! hash helm 2>/dev/null; then
     exit 1
 fi
 
+if ! hash yq 2>/dev/null; then
+    echo "yq is not installed"
+    exit 1
+fi
+
 source "$(dirname "$0")/version"
 source "$(dirname "$0")/util-chart"
 source "$(dirname "$0")/util-team-charts"
+source "$(dirname "$0")/util-kuberlr"
 
 cd "$(dirname "$0")/.."
 
@@ -37,6 +43,11 @@ if [[ "$REPO" != "rancher" ]]; then
 else
   edit-chart ./build/charts/prometheus-federator/Chart.yaml "${HELM_CHART_VERSION}" "${HELM_IMAGE_TAG}"
 fi
+
+KUBERLR_STABLE=$(find_latest_kuberlr_release $KUBERLR_TARGET)
+echo "Setting prometheus-federator cleanup image tag to ${KUBERLR_STABLE}"
+yq -i ".helmProjectOperator.cleanup.image.tag = \"${KUBERLR_STABLE}\"" ./build/charts/prometheus-federator/values.yaml
+
 if ! package-chart ./build/charts/prometheus-federator ./build/charts ; then
   echo "package-chart failed..."
   exit 1


### PR DESCRIPTION
The Prometheus Federator chart embeds a Project Monitoring chart whose kuberlr image is updated at build time. This change ensures the kuberlr image is also updated at build time in the Prometheus Federator chart so that both are using the latest available kuberlr version.

Related Issue: #390 